### PR TITLE
Fix tesla middleware order

### DIFF
--- a/lib/ex_force/client/tesla/tesla.ex
+++ b/lib/ex_force/client/tesla/tesla.ex
@@ -45,8 +45,8 @@ defmodule ExForce.Client.Tesla do
       [
         {ExForce.Client.Tesla.Middleware,
          {instance_url, Keyword.get(opts, :api_version, @default_api_version)}},
-        {Tesla.Middleware.Compression, format: "gzip"},
         {Tesla.Middleware.JSON, engine: Jason},
+        {Tesla.Middleware.Compression, format: "gzip"},
         {Tesla.Middleware.Headers, get_headers(opts)}
       ],
       Keyword.get(opts, :adapter)
@@ -67,10 +67,10 @@ defmodule ExForce.Client.Tesla do
   def build_oauth_client(instance_url, opts \\ []) do
     Tesla.client(
       [
+        {Tesla.Middleware.DecodeJson, engine: Jason},
         {Tesla.Middleware.BaseUrl, instance_url},
         {Tesla.Middleware.Compression, format: "gzip"},
         Tesla.Middleware.FormUrlencoded,
-        {Tesla.Middleware.DecodeJson, engine: Jason},
         {Tesla.Middleware.Headers, get_headers(opts)}
       ],
       Keyword.get(opts, :adapter)


### PR DESCRIPTION
https://dicefm.sentry.io/issues/6784355154/?project=292399&query=is%3Aunresolved&referrer=issue-stream

```
Elixir.Kim.Integrations.Salesforce.Exporters.BaseExporter "Salesforce integration error: status 26894958, reason: {Tesla.Middleware.JSON, :decode, %Jason.DecodeError{position: 0, token: nil, data: <<31, 139, 8, 0, 0, 0, 0, 0, 0, 0, 93, 143, 75, 115, 130, 64, 16, 132, 127, 75, 56, 167, 100, 81, 182, 16, 171, 114, 88, 20, 31, 21, 173, 8, 40, 146, 92, 168, 205, 50, 60, 228, 153, 221, ...>>}}"
```
